### PR TITLE
feat: Implement interactive admin pin drop system (Frontend & Backend)

### DIFF
--- a/client/src/pages/Map.css
+++ b/client/src/pages/Map.css
@@ -84,3 +84,35 @@
 .cancel-btn:hover {
   background: #f0f0f0;
 }
+
+.admin-pin-popup button:disabled {
+  background-color: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.category-badge {
+  display: inline-block;
+  background: #f26a21;
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: bold;
+  width: fit-content;
+}
+
+.delete-pin-btn {
+  background: none;
+  border: none;
+  color: #d32f2f;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 2px 0;
+  margin-top: 4px;
+}
+
+.delete-pin-btn:hover {
+  text-decoration: underline;
+}

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -88,9 +88,19 @@ function ZoomLogger() {
   return null;
 }
 
-function MapClickHandler({ setDraftPin }) {
+function MapClickHandler({ draftPin, setDraftPin }) {
   useMapEvents({
-    click: (e) => setDraftPin(e.latlng),
+    click: (e) => {
+      // Don't create a pin if the user is typing in a form field
+      const tag = document.activeElement?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+      if (draftPin) {
+        setDraftPin(null);
+      } else {
+        setDraftPin(e.latlng);
+      }
+    },
   });
   return null;
 }
@@ -100,6 +110,18 @@ function Map() {
   const [pinName, setPinName] = useState('');
   const [pinCategory, setPinCategory] = useState('');
   const [pinDescription, setPinDescription] = useState('');
+  const [landmarks, setLandmarks] = useState([]);
+
+  // Fetch saved landmarks from the database
+  const fetchLandmarks = async () => {
+    const res = await fetch('http://localhost:5000/api/landmarks');
+    const data = await res.json();
+    setLandmarks(data);
+  };
+
+  useEffect(() => {
+    fetchLandmarks();
+  }, []);
 
   const handleCancel = () => {
     setDraftPin(null);
@@ -107,6 +129,42 @@ function Map() {
     setPinCategory('');
     setPinDescription('');
   };
+
+  // Save a new landmark to the database
+  const handleSave = async () => {
+    const res = await fetch('http://localhost:5000/api/landmarks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: pinName,
+        category: pinCategory,
+        description: pinDescription,
+        coordinates: { latitude: draftPin.lat, longitude: draftPin.lng },
+      }),
+    });
+    if (res.ok) {
+      setDraftPin(null);
+      setPinName('');
+      setPinCategory('');
+      setPinDescription('');
+      fetchLandmarks();
+    }
+  };
+
+  // Delete a landmark from the database
+  const deleteLandmark = async (id) => {
+    const res = await fetch(`http://localhost:5000/api/landmarks/${id}`, {
+      method: 'DELETE',
+    });
+    if (res.ok) {
+      fetchLandmarks();
+    }
+  };
+
+  const isFormValid =
+    pinName.trim() !== '' &&
+    pinCategory !== '' &&
+    pinDescription.trim() !== '';
 
   return (
     <div className="map-page">
@@ -124,7 +182,21 @@ function Map() {
         <LocationMarker />
         <ZoomLogger />
         <MapDebugger />
-        <MapClickHandler setDraftPin={setDraftPin} />
+        <MapClickHandler draftPin={draftPin} setDraftPin={setDraftPin} />
+
+        {/* Permanent landmarks from the database */}
+        {landmarks.map((lm) => (
+          <Marker key={lm._id} position={[lm.coordinates.latitude, lm.coordinates.longitude]}>
+            <Popup>
+              <h3>{lm.name}</h3>
+              <span className="category-badge">{lm.category}</span>
+              <p>{lm.description}</p>
+              <button className="delete-pin-btn" onClick={() => deleteLandmark(lm._id)}>Delete Pin</button>
+            </Popup>
+          </Marker>
+        ))}
+
+        {/* Draft pin for creating a new landmark */}
         {draftPin && (
           <Marker position={draftPin}>
             <Popup className="admin-pin-popup" closeButton={false}>
@@ -153,18 +225,12 @@ function Map() {
               <div className="popup-buttons">
                 <button
                   className="save-btn"
-                  onClick={() =>
-                    console.log('Saving:', {
-                      name: pinName,
-                      category: pinCategory,
-                      description: pinDescription,
-                      coordinates: draftPin,
-                    })
-                  }
+                  disabled={!isFormValid}
+                  onClick={handleSave}
                 >
                   Save Pin
                 </button>
-                <button className="cancel-btn" onClick={handleCancel}>
+                <button className="cancel-btn" onClick={(e) => { e.stopPropagation(); handleCancel(); }}>
                   Cancel
                 </button>
               </div>

--- a/server/models/Landmark.js
+++ b/server/models/Landmark.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 const landmarkSchema = new mongoose.Schema({
   name: { type: String, required: true },
+  category: { type: String },
   description: { type: String },
   coordinates: {
     latitude: { type: Number, required: true },

--- a/server/routes/landmarks.js
+++ b/server/routes/landmarks.js
@@ -23,4 +23,14 @@ router.get('/', async (req, res) => {
   }
 });
 
+// DELETE /:id — delete a landmark
+router.delete('/:id', async (req, res) => {
+  try {
+    await Landmark.findByIdAndDelete(req.params.id);
+    res.json({ message: 'Landmark deleted' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 export default router;


### PR DESCRIPTION
**Description:**
This PR introduces the complete "Admin Pin Drop" feature, allowing authorized users to click anywhere on the map to create, save, and delete permanent campus landmarks. The feature was built with a mobile-first UX and fully integrates our frontend React state with the Express/MongoDB backend.

**Key Changes:**
* **Draft Pin & UX System:** Implemented a smart map click-handler that toggles a temporary "Draft Pin". If a user clicks the map to close an open popup, it safely cleans up the draft pin without accidentally dropping a new one.
* **Interactive Admin Form:** Built a UF-themed (Orange/Blue) Leaflet popup form to capture the Landmark's Name, Category, and Description.
* **Reactive Form Validation:** The "Save Pin" button remains disabled (and grayed out) until all required fields are filled, preventing empty database submissions.
* **Backend Integration:** Wired the form to the Express API. The app now successfully executes `POST` requests to save new pins, and `GET` requests on component mount to load all permanent pins from MongoDB.
* **Pin Management:** Permanent pins now display a cleanly styled Category Badge and feature a "Delete Pin" button that executes a `DELETE` request to the backend for easy map management.

**How to Test:**
1. Pull down this branch and ensure your local backend server (`npm run dev` in `/server`) is running.
2. Navigate to the Map view. Any existing pins in your local MongoDB should render automatically.
3. Click anywhere on the map to drop a blue Draft Pin.
4. Click the pin to open the form. Verify the "Save Pin" button is disabled.
5. Fill out the Name, select a Category, and add a Description. Verify the button turns orange.
6. Click "Save Pin". The form should close, and the permanent pin should take its place.
7. Refresh the page to verify the pin persists.
8. Click the new permanent pin and click "Delete Pin" to verify it is removed from the map and database.