### PR TITLE
Fix signup 500 error

### DIFF
--- a/client/src/apiBase.js
+++ b/client/src/apiBase.js
@@ -1,0 +1,12 @@
+/**
+ * Base URL for the Express API. Leave unset in dev so requests use same origin
+ * and Vite proxies `/api` to the backend (see vite.config.js).
+ * For a split deploy (e.g. static site + API host), set VITE_API_URL in `.env`.
+ */
+export function apiUrl(path) {
+  const raw = import.meta.env.VITE_API_URL ?? '';
+  const base = raw.replace(/\/$/, '');
+  const p = path.startsWith('/') ? path : `/${path}`;
+  if (!base) return p;
+  return `${base}${p}`;
+}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -2,6 +2,7 @@
 // saving jwt token idea from https://www.freecodecamp.org/news/how-to-authenticate-users-in-your-node-app-using-cookies-sessions-and-jwt/
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { apiUrl } from '../apiBase';
 import './Auth.css';
 
 function Login() {
@@ -27,7 +28,7 @@ function Login() {
     }
 
     try {
-      const res = await fetch('http://localhost:5000/api/auth/login', {
+      const res = await fetch(apiUrl('/api/auth/login'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -2,6 +2,7 @@
 // geolocation api from https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
 import { useState, useEffect, useRef } from 'react';
 import { MapContainer, TileLayer, CircleMarker, Marker, Popup, useMap, useMapEvents } from 'react-leaflet';
+import { apiUrl } from '../apiBase';
 import 'leaflet/dist/leaflet.css';
 import './Map.css';
 
@@ -84,7 +85,7 @@ function Map() {
 
   // fetches saved landmarks from the database
   const fetchLandmarks = async () => {
-    const res = await fetch('http://localhost:5000/api/landmarks');
+    const res = await fetch(apiUrl('/api/landmarks'));
     const data = await res.json();
     setLandmarks(data);
   };
@@ -102,7 +103,7 @@ function Map() {
 
   // saves a new landmark to the database
   const handleSave = async () => {
-    const res = await fetch('http://localhost:5000/api/landmarks', {
+    const res = await fetch(apiUrl('/api/landmarks'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -123,7 +124,7 @@ function Map() {
 
   // deletes a landmark from the database
   const deleteLandmark = async (id) => {
-    const res = await fetch(`http://localhost:5000/api/landmarks/${id}`, {
+    const res = await fetch(apiUrl(`/api/landmarks/${id}`), {
       method: 'DELETE',
     });
     if (res.ok) {

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,6 +1,7 @@
 // same auth pattern as Login.jsx
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { apiUrl } from '../apiBase';
 import './Auth.css';
 
 function Signup() {
@@ -22,7 +23,7 @@ function Signup() {
     setPasswordError('');
 
     try {
-      const res = await fetch('http://localhost:5000/api/auth/signup', {
+      const res = await fetch(apiUrl('/api/auth/signup'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,7 +1,37 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+/** Read `PORT` from `server/.env` only (do not load that file into `process.env` — it would clash with Vite). */
+function backendPortFromServerEnv() {
+  const envPath = path.resolve(__dirname, '../server/.env')
+  try {
+    const raw = fs.readFileSync(envPath, 'utf8')
+    const line = raw.split(/\r?\n/).find((l) => /^PORT\s*=/i.test(l))
+    if (!line) return 5000
+    const value = line.replace(/^PORT\s*=\s*/i, '').trim().replace(/^["']|["']$/g, '')
+    const n = Number(value)
+    return Number.isFinite(n) && n > 0 ? n : 5000
+  } catch {
+    return 5000
+  }
+}
+
+const backendPort = backendPortFromServerEnv()
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: `http://127.0.0.1:${backendPort}`,
+        changeOrigin: true,
+      },
+    },
+  },
 })

--- a/server/server.js
+++ b/server/server.js
@@ -25,4 +25,5 @@ app.get('/api/health', (req, res) => res.json({ status: 'ok' }));
 app.use('/api/auth', authRoutes);
 app.use('/api/landmarks', landmarkRoutes);
 
-app.listen(process.env.PORT || 5000, () => console.log('Server on port 5000'));
+const port = Number(process.env.PORT) || 5000;
+app.listen(port, () => console.log(`Server on port ${port}`));


### PR DESCRIPTION
Fix signup 500 error caused by incorrect Vite proxy port (macOS local dev fix)

The Express server runs on the port defined in server/.env (PORT=5174 on my Mac),
but the Vite dev proxy was still targeting http://localhost:5000.

This caused /api/auth/signup requests to hit the wrong backend,
resulting in 500 errors or invalid text/plain responses.

Fix:
- Updated vite.config.js to read PORT from server/.env
- Set proxy target dynamically to http://127.0.0.1:${PORT}
- Added server startup log to confirm active port

Notes:
- This is a local development fix for macOS setup.
- It does NOT hardcode a machine-specific port; it uses server/.env, so other environments remain unaffected as long as their PORT matches their backend config.
- If teammates use a different PORT, they only need to ensure server/.env and backend match (no code changes required).
