### PR TITLE
Fix: Enforce 500-char limit on pin description input

### DIFF
--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -187,9 +187,11 @@ function Map() {
               </select>
               <textarea
                 placeholder="Description"
+                maxLength={500}
                 value={pinDescription}
                 onChange={(e) => setPinDescription(e.target.value)}
               />
+              <small>{pinDescription.length}/500</small>
               <div className="popup-buttons">
                 <button
                   className="save-btn"


### PR DESCRIPTION
## Summary
Adds a 500-character limit to the pin drop description field to prevent
excessively long descriptions from being submitted.

## Changes
- Added `maxLength={500}` to the description `<textarea>` to enforce the
  character limit at the input level
- Added a `<small>` character counter (`0/500`) below the textarea so
  users can see how many characters they have remaining

## Files Changed
- `client/src/pages/Map.jsx`

## Testing
- Verified that typing beyond 500 characters is blocked by the input
- Character counter updates in real time as the user types