### PR TITLE
Feat: Implemented filter and reveal for fog of war

### DIFF
--- a/client/src/pages/FogOfWar.jsx
+++ b/client/src/pages/FogOfWar.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState, useLayoutEffect } from 'react';
+import { useMap, TileLayer } from 'react-leaflet';
+
+// How many meters around the user to show in full color
+const REVEAL_RADIUS = 200;
+
+function FogOfWar() {
+  const map = useMap();
+  const [position, setPosition] = useState(null);
+  const [paneReady, setPaneReady] = useState(false);
+
+  // Create the "reveal" pane BEFORE first paint (useLayoutEffect)
+  // so the TileLayer can safely render into it
+  useLayoutEffect(() => {
+    if (!map.getPane('fogRevealPane')) {
+      const pane = map.createPane('fogRevealPane');
+      pane.style.zIndex = '250';
+      // Start fully hidden until we know where the user is
+      pane.style.clipPath = 'circle(0px at 0px 0px)';
+    }
+    setPaneReady(true);
+  }, [map]);
+
+  // Watch the user's GPS position
+  useEffect(() => {
+    if (!navigator.geolocation) return;
+
+    const onPosition = (geo) => {
+      setPosition([geo.coords.latitude, geo.coords.longitude]);
+    };
+    const opts = { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 };
+
+    navigator.geolocation.getCurrentPosition(onPosition, () => {}, opts);
+    const watchId = navigator.geolocation.watchPosition(onPosition, () => {}, opts);
+    return () => navigator.geolocation.clearWatch(watchId);
+  }, []);
+
+  // Update the clip circle whenever the map moves/zooms or user moves
+  useEffect(() => {
+    if (!position) return;
+    const pane = map.getPane('fogRevealPane');
+    if (!pane) return;
+
+    function updateClip() {
+      // Convert the user's GPS position to pixel coords in the pane
+      const center = map.latLngToLayerPoint(position);
+
+      // Convert REVEAL_RADIUS (meters) to pixels at the current zoom
+      // 1 degree of latitude ≈ 111,320 meters
+      const degOffset = REVEAL_RADIUS / 111320;
+      const edge = map.latLngToLayerPoint([position[0] + degOffset, position[1]]);
+      const radiusPx = Math.abs(center.y - edge.y);
+
+      pane.style.clipPath = `circle(${radiusPx}px at ${center.x}px ${center.y}px)`;
+    }
+
+    updateClip();
+    map.on('move zoom viewreset', updateClip);
+    return () => map.off('move zoom viewreset', updateClip);
+  }, [map, position]);
+
+  // Only render the color TileLayer after the pane exists
+  if (!paneReady) return null;
+
+  return (
+    <TileLayer
+      url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      pane="fogRevealPane"
+    />
+  );
+}
+
+export default FogOfWar;

--- a/client/src/pages/Map.css
+++ b/client/src/pages/Map.css
@@ -116,3 +116,7 @@
 .delete-pin-btn:hover {
   text-decoration: underline;
 }
+
+.fog-gray {
+  filter: brightness(0.1);
+}

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -5,6 +5,7 @@ import { MapContainer, TileLayer, CircleMarker, Marker, Popup, useMap, useMapEve
 import { apiUrl } from '../apiBase';
 import 'leaflet/dist/leaflet.css';
 import './Map.css';
+import FogOfWar from './FogOfWar';
 
 const UF_CENTER = [29.6436, -82.3549];
 
@@ -147,9 +148,11 @@ function Map() {
         scrollWheelZoom={true}
       >
         <TileLayer
+          className="fog-gray"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
+        <FogOfWar />
         <LocationMarker />
         {isAdmin && <MapClickHandler draftPin={draftPin} setDraftPin={setDraftPin} />}
 


### PR DESCRIPTION
## Fog of War

Adds a fog of war effect to the map. The map appears **dark/hidden by default**, and a full-color circle reveals around the user's GPS position as they explore.

### What it does
- Map tiles are darkened to 10% brightness by default (fog)
- A **200m radius** circle around the user's live GPS position shows the map in full color
- Markers, popups, and pins remain fully visible and unaffected
- The reveal circle follows the user in real-time and adjusts correctly when panning/zooming

### How it works
- A second `TileLayer` (full color) is rendered in a custom Leaflet pane sitting just above the darkened tiles
- The pane is clipped to a circle using CSS `clip-path`, centered on the user's GPS coordinates
- The clip updates on every map `move`, `zoom`, and `viewreset` event

### Files changed
| File | Change |
|---|---|
| `client/src/pages/FogOfWar.jsx` | **New** — self-contained component handling pane creation, GPS tracking, and clip-path updates |
| `client/src/pages/Map.jsx` | +4 lines — import, `className` on TileLayer, `<FogOfWar />` render |
| `client/src/pages/Map.css` | +3 lines — `.fog-gray` filter appended at bottom |

### Next steps
- [ ] MongoDB persistence for explored areas (so fog stays cleared across sessions)