### PR TITLE
Fix: Remove Challenges tab from top navigation bar

### DIFF
--- a/client/src/components/AppLayout.jsx
+++ b/client/src/components/AppLayout.jsx
@@ -1,10 +1,9 @@
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
-import { Map, Trophy, CircleStar, User } from 'lucide-react';
+import { Map, CircleStar, User } from 'lucide-react';
 import './AppLayout.css';
 
 const TABS = [
   { label: 'Map', path: '/app/map', Icon: Map },
-  { label: 'Challenges', path: '/app/challenges', Icon: Trophy },
   { label: 'Badges', path: '/app/badges', Icon: CircleStar },
   { label: 'Profile', path: '/app/profile', Icon: User },
 ];


### PR DESCRIPTION
## Summary
Removes the Challenges button from the top navigation bar, leaving only Map, Badges, and Profile.

## Changes
- **`client/src/components/AppLayout.jsx`**: Removed the Challenges entry from the `TABS` array and the unused `Trophy` icon import.

No layout or CSS changes needed — the remaining three tabs distribute evenly automatically.