### PR TITLE
Feat: Removed placeholder challenges text and added challenges below …

### DIFF
--- a/client/src/pages/Badges.css
+++ b/client/src/pages/Badges.css
@@ -120,3 +120,33 @@
   font-weight: 700;
   color: var(--gw-muted);
 }
+
+.challenges-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  max-height: 300px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.challenge-item {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 0.85rem;
+}
+
+.challenge-item__name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #fff;
+  margin-bottom: 0.25rem;
+}
+
+.challenge-item__desc {
+  font-size: 0.85rem;
+  color: var(--gw-muted);
+  line-height: 1.4;
+}

--- a/client/src/pages/Badges.jsx
+++ b/client/src/pages/Badges.jsx
@@ -1,8 +1,59 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+
 import { BADGES, PLANNED_CHALLENGE_COUNT } from '../data/badges';
 import { getCompletedChallengeIds } from '../lib/challengeProgress';
 import './Badges.css';
+
+const CHALLENGES = [
+  {
+    "name": "Freshman Orientation",
+    "description": "Visit your very first pin anywhere on the map and correctly answer its trivia question to begin your journey."
+  },
+  {
+    "name": "The Campus Tour Guide",
+    "description": "Visit and conquer the fundamental staples of the UF campus. You must complete the pins at Century Tower, Ben Hill Griffin Stadium, the J. Wayne Reitz Union, and Plaza of the Americas."
+  },
+  {
+    "name": "Landmark Legend",
+    "description": "Visit and correctly answer the trivia at all locations in the Landmarks category: Century Tower, The \"French Fries\" (Alachua) Sculpture, University Auditorium, The Bat Houses, and the Albert and Alberta Statues."
+  },
+  {
+    "name": "Dining Connoisseur",
+    "description": "Visit and correctly answer the trivia at all locations in the Dining category: Gator Corner Dining Center, Broward Dining, The Hub, and the Reitz Union Food Court."
+  },
+  {
+    "name": "The Resident",
+    "description": "Visit and correctly answer the trivia at all locations in the Housing category: Broward Hall, Hume Hall, Beaty Towers, and the historic Murphree Hall."
+  },
+  {
+    "name": "The Bookworm",
+    "description": "Visit and correctly answer the trivia at all locations in the Libraries category: Library West, Marston Science Library, Smathers Library (East), and the Architecture & Fine Arts (AFA) Library."
+  },
+  {
+    "name": "The Historic Gator",
+    "description": "Complete the trivia at UF's oldest and most historically significant buildings by visiting Murphree Hall, Smathers Library (East), and University Auditorium."
+  },
+  {
+    "name": "The STEM Scholar",
+    "description": "Complete the trivia at the science and engineering-focused locations by visiting Marston Science Library, Hume Hall, and The Bat Houses."
+  },
+  {
+    "name": "The Arts & Culture Critic",
+    "description": "Complete the trivia at UF's creative hubs by visiting the Architecture & Fine Arts Library, the University Auditorium, and the \"French Fries\" (Alachua) Sculpture."
+  },
+  {
+    "name": "The East Campus Explorer",
+    "description": "Complete the trivia for the pins clustered on the eastern side of campus by visiting Beaty Towers, Broward Hall, and Broward Dining."
+  },
+  {
+    "name": "The Heart of Campus",
+    "description": "Complete the trivia for the high-traffic central campus pins by visiting Library West, The Hub, and Century Tower."
+  },
+  {
+    "name": "The True Florida Gator",
+    "description": "Achieve 100% completion. Visit every single pin across all four categories (Landmarks, Dining, Housing, and Libraries) and answer all the trivia questions correctly."
+  }
+];
 
 function buildStats(completedIds) {
   const totalChallenges = PLANNED_CHALLENGE_COUNT;
@@ -67,10 +118,6 @@ function Badges() {
   return (
     <div className="gw-page badges-page">
       <div className="gw-page-inner">
-        <p className="gw-lead">
-          challenges coming soon, will update according to progress bar
-        </p>
-
         <section className="showcase-card" aria-labelledby="badge-collector-heading">
           <h2 className="showcase-card__header" id="badge-collector-heading">
             Badge collector
@@ -129,23 +176,13 @@ function Badges() {
             Challenge mastery
           </h2>
           <div className="showcase-card__body">
-            <div className="showcase-icon-row" role="list">
-              {stats.showcaseBadges.length === 0 ? (
-                <p className="gw-lead" style={{ margin: 0 }}>
-                  When challenges go live, your latest badges will appear in this row.
-                </p>
-              ) : (
-                stats.showcaseBadges.map((b) => (
-                  <div
-                    key={b.id}
-                    className={`badge-slot badge-slot--unlocked ${b.tier}`}
-                    role="listitem"
-                    title={b.name}
-                  >
-                    <span className="badge-slot__abbr">{b.abbr}</span>
-                  </div>
-                ))
-              )}
+            <div className="challenges-list" role="list">
+              {CHALLENGES.map((c, i) => (
+                <div key={i} className="challenge-item" role="listitem">
+                  <div className="challenge-item__name">{c.name}</div>
+                  <div className="challenge-item__desc">{c.description}</div>
+                </div>
+              ))}
             </div>
 
             <div className="showcase-stat-row showcase-stat-row--duo">
@@ -165,9 +202,6 @@ function Badges() {
           </div>
         </section>
 
-        <Link className="link-challenges" to="/app/challenges">
-          Challenges (coming soon) →
-        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Updates the Badges page to replace the placeholder challenge UI with the actual upcoming challenge list and cleans up temporary "coming soon" text.

## Changes
- **`client/src/pages/Badges.jsx`**:
  - Removed the "challenges coming soon" lead paragraph at the top of the page.
  - Removed the unused `react-router-dom` `Link` import and the routing link to the non-existent Challenges page from the bottom.
  - Replaced the placeholder text in the "Challenge mastery" card with the actual list of 12 planned challenges (names and descriptions).
- **`client/src/pages/Badges.css`**:
  - Added simple, consistent styling for `.challenges-list` and `.challenge-item` to present the new challenges in a clean, scrollable view that matches the existing dark theme aesthetic.