### PR TITLE
Feat/proximity to pin

### DIFF
--- a/client/src/pages/Map.css
+++ b/client/src/pages/Map.css
@@ -70,6 +70,13 @@
   background: #d95a18;
 }
 
+.save-btn:disabled {
+  background-color: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .cancel-btn {
   flex: 1;
   padding: 4px 0;
@@ -104,15 +111,174 @@
 }
 
 .delete-pin-btn {
-  background: none;
+  flex: 1;
+  padding: 6px 10px;
+  background: #d32f2f;
+  color: #fff;
   border: none;
-  color: #d32f2f;
+  border-radius: 4px;
   font-size: 11px;
+  font-weight: bold;
   cursor: pointer;
-  padding: 2px 0;
-  margin-top: 4px;
 }
 
 .delete-pin-btn:hover {
-  text-decoration: underline;
+  background: #b71c1c;
+  text-decoration: none;
+}
+
+/* proximity pin (unanswered) - shifts the default blue marker to red */
+.pin-near-icon,
+.pin-completed-icon {
+  background: transparent;
+  border: none;
+}
+
+.pin-near-img {
+  width: 25px;
+  height: 41px;
+  filter: hue-rotate(140deg) saturate(4) brightness(1);
+}
+
+/* completed pin - shifts the default blue marker to orange */
+.pin-completed-img {
+  width: 25px;
+  height: 41px;
+  filter: hue-rotate(173deg) saturate(2) brightness(1.1);
+}
+
+/* trivia button on info view */
+.trivia-btn {
+  margin-top: 6px;
+  padding: 6px 10px;
+  background: #f26a21;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: bold;
+  cursor: pointer;
+  width: 100%;
+}
+
+.trivia-btn:hover {
+  background: #d95a18;
+}
+
+/* admin-only 'add trivia' button in the info view */
+.add-trivia-btn {
+  flex: 1;
+  padding: 6px 10px;
+  background: #f26a21;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.add-trivia-btn:hover {
+  background: #d95a18;
+}
+
+/* trivia view styles */
+.trivia-question {
+  font-size: 12px;
+  color: #222;
+  margin: 6px 0;
+  line-height: 1.35;
+}
+
+.trivia-options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.trivia-option-btn {
+  padding: 6px 8px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+  color: #222;
+}
+
+.trivia-option-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #f26a21;
+}
+
+.trivia-option-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.trivia-incorrect {
+  color: #c00505;
+  font-size: 12px;
+  font-weight: bold;
+  margin: 6px 0;
+}
+
+/* admin create-pin trivia section */
+.trivia-admin-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+  padding-top: 6px;
+  border-top: 1px solid #eee;
+}
+
+.trivia-admin-section textarea {
+  width: 100%;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 11px;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 36px;
+  font-family: inherit;
+}
+
+.trivia-admin-section textarea:focus {
+  outline: none;
+  border-color: #00529b;
+}
+
+.trivia-save-error {
+  color: #d32f2f;
+  font-size: 11px;
+  margin: 4px 0 0;
+}
+
+.trivia-admin-label {
+  color: #666;
+  font-weight: bold;
+}
+
+.trivia-admin-option-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.trivia-admin-option-row input[type="radio"] {
+  width: auto;
+  margin: 0;
+  flex: 0 0 auto;
+}
+
+.trivia-admin-option-row input[type="text"] {
+  flex: 1;
+}
+
+.trivia-form-buttons {
+  margin-top: 10px;
 }

--- a/client/src/pages/Map.css
+++ b/client/src/pages/Map.css
@@ -70,6 +70,13 @@
   background: #d95a18;
 }
 
+.save-btn:disabled {
+  background-color: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .cancel-btn {
   flex: 1;
   padding: 4px 0;
@@ -104,17 +111,176 @@
 }
 
 .delete-pin-btn {
-  background: none;
+  flex: 1;
+  padding: 6px 10px;
+  background: #d32f2f;
+  color: #fff;
   border: none;
-  color: #d32f2f;
+  border-radius: 4px;
   font-size: 11px;
+  font-weight: bold;
   cursor: pointer;
-  padding: 2px 0;
-  margin-top: 4px;
 }
 
 .delete-pin-btn:hover {
-  text-decoration: underline;
+  background: #b71c1c;
+  text-decoration: none;
+}
+
+/* proximity pin (unanswered) - shifts the default blue marker to red */
+.pin-near-icon,
+.pin-completed-icon {
+  background: transparent;
+  border: none;
+}
+
+.pin-near-img {
+  width: 25px;
+  height: 41px;
+  filter: hue-rotate(140deg) saturate(4) brightness(1);
+}
+
+/* completed pin - shifts the default blue marker to orange */
+.pin-completed-img {
+  width: 25px;
+  height: 41px;
+  filter: hue-rotate(173deg) saturate(2) brightness(1.1);
+}
+
+/* trivia button on info view */
+.trivia-btn {
+  margin-top: 6px;
+  padding: 6px 10px;
+  background: #f26a21;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: bold;
+  cursor: pointer;
+  width: 100%;
+}
+
+.trivia-btn:hover {
+  background: #d95a18;
+}
+
+/* admin-only 'add trivia' button in the info view */
+.add-trivia-btn {
+  flex: 1;
+  padding: 6px 10px;
+  background: #f26a21;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.add-trivia-btn:hover {
+  background: #d95a18;
+}
+
+/* trivia view styles */
+.trivia-question {
+  font-size: 12px;
+  color: #222;
+  margin: 6px 0;
+  line-height: 1.35;
+}
+
+.trivia-options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.trivia-option-btn {
+  padding: 6px 8px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+  color: #222;
+}
+
+.trivia-option-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #f26a21;
+}
+
+.trivia-option-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.trivia-incorrect {
+  color: #c00505;
+  font-size: 12px;
+  font-weight: bold;
+  margin: 6px 0;
+}
+
+/* admin create-pin trivia section */
+.trivia-admin-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+  padding-top: 6px;
+  border-top: 1px solid #eee;
+}
+
+.trivia-admin-section textarea {
+  width: 100%;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 11px;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 36px;
+  font-family: inherit;
+}
+
+.trivia-admin-section textarea:focus {
+  outline: none;
+  border-color: #00529b;
+}
+
+.trivia-save-error {
+  color: #d32f2f;
+  font-size: 11px;
+  margin: 4px 0 0;
+}
+
+.trivia-admin-label {
+  color: #666;
+  font-weight: bold;
+}
+
+.trivia-admin-option-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.trivia-admin-option-row input[type="radio"] {
+  width: auto;
+  margin: 0;
+  flex: 0 0 auto;
+}
+
+.trivia-admin-option-row input[type="text"] {
+  flex: 1;
+}
+
+.trivia-form-buttons {
+  margin-top: 10px;
 }
 
 .fog-gray {

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -1,14 +1,36 @@
 // react-leaflet setup from https://react-leaflet.js.org/docs/start-setup/
 // geolocation api from https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
 import { useState, useEffect, useRef } from 'react';
-import { MapContainer, TileLayer, CircleMarker, Marker, Popup, useMap, useMapEvents } from 'react-leaflet';
+import { MapContainer, TileLayer, CircleMarker, Circle, Marker, Popup, useMap, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import markerIconUrl from 'leaflet/dist/images/marker-icon.png';
 import { apiUrl } from '../apiBase';
 import 'leaflet/dist/leaflet.css';
 import './Map.css';
 
 const UF_CENTER = [29.6436, -82.3549];
+const PROXIMITY_METERS = 100;
 
-function LocationMarker() {
+// pin colors are blue by default, red if in proximity but unanswered, and orange if answered
+const nearIcon = L.divIcon({
+  className: 'pin-near-icon',
+  html: `<img src="${markerIconUrl}" class="pin-near-img" alt="" />`,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+});
+
+const completedIcon = L.divIcon({
+  className: 'pin-completed-icon',
+  html: `<img src="${markerIconUrl}" class="pin-completed-img" alt="" />`,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+});
+
+const defaultIcon = new L.Icon.Default();
+
+function LocationMarker({ onPosition }) {
   const [position, setPosition] = useState(null);
   const hasPannedRef = useRef(false);
 
@@ -16,7 +38,9 @@ function LocationMarker() {
     if (!navigator.geolocation) return;
 
     const onSuccess = (pos) => {
-      setPosition([pos.coords.latitude, pos.coords.longitude]);
+      const next = [pos.coords.latitude, pos.coords.longitude];
+      setPosition(next);
+      onPosition?.({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
     };
     const onErr = () => setPosition(null);
     const opts = { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 };
@@ -24,7 +48,7 @@ function LocationMarker() {
     navigator.geolocation.getCurrentPosition(onSuccess, onErr, opts);
     const watchId = navigator.geolocation.watchPosition(onSuccess, onErr, opts);
     return () => navigator.geolocation.clearWatch(watchId);
-  }, []);
+  }, [onPosition]);
 
   if (!position) return null;
 
@@ -58,6 +82,9 @@ function PanToUser({ position, hasPannedRef }) {
 function MapClickHandler({ draftPin, setDraftPin }) {
   useMapEvents({
     click: (e) => {
+      const target = e.originalEvent?.target;
+      if (target && target.closest && target.closest('.leaflet-popup')) return;
+
       // clicking map while typing in popup was creating pins - this fixes it
       const tag = document.activeElement?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
@@ -72,6 +99,254 @@ function MapClickHandler({ draftPin, setDraftPin }) {
   return null;
 }
 
+function LandmarkPopup({
+  lm,
+  isAdmin,
+  isNear,
+  isCompleted,
+  triviaDoc,
+  currentUser,
+  onCorrect,
+  onDelete,
+  onTriviaSaved,
+}) {
+  const map = useMap();
+  const [view, setView] = useState('info');
+  const [submitting, setSubmitting] = useState(false);
+
+  const hasTrivia = !!triviaDoc;
+
+  const [newQuestion, setNewQuestion] = useState('');
+  const [newOptions, setNewOptions] = useState(['', '', '']);
+  const [newCorrectIndex, setNewCorrectIndex] = useState(0);
+
+  // admins see the orange pin / proximity circle but never answer trivia
+  const shouldAutoOpenTrivia = !isAdmin && isNear && hasTrivia && !isCompleted;
+
+  // when this landmark's popup opens, auto-jump to the trivia view for explorers
+  // standing next to an unanswered pin. matches the popup's source marker by
+  // latlng so we don't react to other pins' popup events.
+  useMapEvents({
+    popupopen: (e) => {
+      const srcLatLng = e.popup?._source?.getLatLng?.();
+      if (
+        srcLatLng &&
+        srcLatLng.lat === lm.coordinates.latitude &&
+        srcLatLng.lng === lm.coordinates.longitude
+      ) {
+        setView(shouldAutoOpenTrivia ? 'trivia' : 'info');
+      }
+    },
+  });
+
+  const handleAnswer = async (idx) => {
+    if (submitting || !triviaDoc) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(apiUrl(`/api/trivia/${triviaDoc._id}/answer`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: currentUser?.id,
+          answerIndex: idx,
+        }),
+      });
+      const data = await res.json();
+      if (data.correct) {
+        onCorrect(triviaDoc._id, data.completedTrivia);
+        setView('info');
+        map.closePopup();
+      } else {
+        setView('incorrect');
+      }
+    } catch {
+      setView('incorrect');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const resetAddTrivia = () => {
+    setNewQuestion('');
+    setNewOptions(['', '', '']);
+    setNewCorrectIndex(0);
+  };
+
+  const [triviaError, setTriviaError] = useState('');
+
+  const handleSaveTrivia = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setTriviaError('');
+    try {
+      let res;
+      if (hasTrivia) {
+        res = await fetch(apiUrl(`/api/trivia/${triviaDoc._id}`), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            question: newQuestion.trim(),
+            options: newOptions.map((o) => o.trim()),
+            correctIndex: newCorrectIndex,
+          }),
+        });
+      } else {
+        res = await fetch(apiUrl('/api/trivia'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            coordinates: {
+              latitude: lm.coordinates.latitude,
+              longitude: lm.coordinates.longitude,
+            },
+            question: newQuestion.trim(),
+            options: newOptions.map((o) => o.trim()),
+            correctIndex: newCorrectIndex,
+          }),
+        });
+      }
+      if (res.ok) {
+        await onTriviaSaved();
+        setView('info');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        const msg = body.error || `Server error ${res.status}`;
+        setTriviaError(`${msg} (id: ${triviaDoc?._id ?? 'undefined'})`);
+        console.error('[handleSaveTrivia]', res.status, body, 'id:', triviaDoc?._id);
+      }
+    } catch (err) {
+      setTriviaError('Network error — check the server.');
+      console.error('[handleSaveTrivia] fetch failed', err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSaveTrivia =
+    newQuestion.trim() !== '' && newOptions.every((o) => o.trim() !== '');
+
+  if (view === 'trivia' && hasTrivia) {
+    return (
+      <>
+        <p className="trivia-question">{triviaDoc.question}</p>
+        <div className="trivia-options">
+          {triviaDoc.options.map((opt, i) => (
+            <button
+              key={i}
+              className="trivia-option-btn"
+              disabled={submitting}
+              onClick={() => handleAnswer(i)}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  if (view === 'incorrect') {
+    return (
+      <>
+        <h3>{lm.name}</h3>
+        <p className="trivia-incorrect">Incorrect, try again.</p>
+        <div className="popup-buttons trivia-form-buttons">
+          <button className="save-btn" onClick={(e) => { e.stopPropagation(); e.preventDefault(); setView('trivia'); }}>Try again</button>
+          <button className="cancel-btn" onClick={(e) => { e.stopPropagation(); e.preventDefault(); setView('info'); }}>Back</button>
+        </div>
+      </>
+    );
+  }
+
+  if (view === 'triviaForm') {
+    return (
+      <>
+        <h3>{hasTrivia ? 'Edit Trivia' : 'Add Trivia'}</h3>
+        <div className="trivia-admin-section">
+          <textarea
+            placeholder="Trivia question"
+            maxLength={500}
+            value={newQuestion}
+            onChange={(e) => setNewQuestion(e.target.value)}
+          />
+          {newOptions.map((opt, i) => (
+            <div key={i} className="trivia-admin-option-row">
+              <input
+                type="radio"
+                name="trivia-correct"
+                checked={newCorrectIndex === i}
+                onChange={() => setNewCorrectIndex(i)}
+                title="Mark as correct answer"
+              />
+              <input
+                type="text"
+                placeholder={`Option ${i + 1}`}
+                value={opt}
+                onChange={(e) => {
+                  const next = [...newOptions];
+                  next[i] = e.target.value;
+                  setNewOptions(next);
+                }}
+              />
+            </div>
+          ))}
+        </div>
+        {triviaError && <p className="trivia-save-error">{triviaError}</p>}
+        <div className="popup-buttons">
+          <button
+            className="save-btn"
+            disabled={!canSaveTrivia || submitting}
+            onClick={(e) => { e.stopPropagation(); e.preventDefault(); handleSaveTrivia(); }}
+          >
+            {submitting ? 'Saving…' : 'Save Trivia'}
+          </button>
+          <button
+            className="cancel-btn"
+            onClick={(e) => { e.stopPropagation(); e.preventDefault(); setView('info'); }}
+          >
+            Cancel
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h3>{lm.name}</h3>
+      <span className="category-badge">{lm.category}</span>
+      <p>{lm.description}</p>
+      {isAdmin && (
+        <div className="popup-buttons">
+          <button
+            className="add-trivia-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              if (hasTrivia) {
+                setNewQuestion(triviaDoc.question);
+                setNewOptions([...triviaDoc.options]);
+                setNewCorrectIndex(triviaDoc.correctIndex);
+              } else {
+                resetAddTrivia();
+              }
+              setView('triviaForm');
+            }}
+          >
+            {hasTrivia ? 'Edit Trivia' : 'Add Trivia'}
+          </button>
+          <button
+            className="delete-pin-btn"
+            onClick={(e) => { e.stopPropagation(); e.preventDefault(); onDelete(lm._id); }}
+          >
+            Delete Pin
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
 function Map() {
   const userStr = localStorage.getItem('authUser') || sessionStorage.getItem('authUser');
   const currentUser = userStr ? JSON.parse(userStr) : null;
@@ -82,6 +357,11 @@ function Map() {
   const [pinCategory, setPinCategory] = useState('');
   const [pinDescription, setPinDescription] = useState('');
   const [landmarks, setLandmarks] = useState([]);
+  const [trivia, setTrivia] = useState([]);
+  const [userPos, setUserPos] = useState(null);
+  const [completedTriviaIds, setCompletedTriviaIds] = useState(
+    () => new Set(currentUser?.completedTrivia ?? [])
+  );
 
   // fetches saved landmarks from the database
   const fetchLandmarks = async () => {
@@ -90,8 +370,16 @@ function Map() {
     setLandmarks(data);
   };
 
+  // fetches trivia entries (separate collection, joined to landmarks by coordinates)
+  const fetchTrivia = async () => {
+    const res = await fetch(apiUrl('/api/trivia'));
+    const data = await res.json();
+    setTrivia(data);
+  };
+
   useEffect(() => {
     fetchLandmarks();
+    fetchTrivia();
   }, []);
 
   const handleCancel = () => {
@@ -114,10 +402,7 @@ function Map() {
       }),
     });
     if (res.ok) {
-      setDraftPin(null);
-      setPinName('');
-      setPinCategory('');
-      setPinDescription('');
+      handleCancel();
       fetchLandmarks();
     }
   };
@@ -131,6 +416,39 @@ function Map() {
       fetchLandmarks();
     }
   };
+
+  // called by LandmarkPopup when the user answers correctly
+  const handleCorrectAnswer = (triviaId, completedFromServer) => {
+    setCompletedTriviaIds((prev) => {
+      const next = new Set(prev);
+      next.add(triviaId);
+      return next;
+    });
+
+    // persist on the stored user so it survives a refresh
+    const listFromServer = Array.isArray(completedFromServer) ? completedFromServer : null;
+    const storageKey = 'authUser';
+    const stored =
+      localStorage.getItem(storageKey) || sessionStorage.getItem(storageKey);
+    if (!stored) return;
+    try {
+      const parsed = JSON.parse(stored);
+      parsed.completedTrivia = listFromServer
+        ?? Array.from(new Set([...(parsed.completedTrivia || []), triviaId]));
+      const target = localStorage.getItem(storageKey) ? localStorage : sessionStorage;
+      target.setItem(storageKey, JSON.stringify(parsed));
+    } catch {
+      // ignore bad JSON
+    }
+  };
+
+  // find a Trivia doc that matches a landmark by exact coordinate equality
+  const findTriviaForPin = (lm) =>
+    trivia.find(
+      (t) =>
+        t.coordinates.latitude === lm.coordinates.latitude &&
+        t.coordinates.longitude === lm.coordinates.longitude
+    );
 
   const isFormValid =
     pinName.trim() !== '' &&
@@ -150,20 +468,59 @@ function Map() {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        <LocationMarker />
+        <LocationMarker onPosition={setUserPos} />
+        {isAdmin && userPos && (
+          <Circle
+            center={[userPos.latitude, userPos.longitude]}
+            radius={PROXIMITY_METERS}
+            pathOptions={{
+              color: '#f26a21',
+              weight: 2,
+              dashArray: '6 6',
+              fillColor: '#f26a21',
+              fillOpacity: 0.08,
+            }}
+          />
+        )}
         {isAdmin && <MapClickHandler draftPin={draftPin} setDraftPin={setDraftPin} />}
 
         {/* permanent landmarks from db */}
-        {landmarks.map((lm) => (
-          <Marker key={lm._id} position={[lm.coordinates.latitude, lm.coordinates.longitude]}>
-            <Popup>
-              <h3>{lm.name}</h3>
-              <span className="category-badge">{lm.category}</span>
-              <p>{lm.description}</p>
-              {isAdmin && <button className="delete-pin-btn" onClick={() => deleteLandmark(lm._id)}>Delete Pin</button>}
-            </Popup>
-          </Marker>
-        ))}
+        {landmarks.map((lm) => {
+          const triviaDoc = findTriviaForPin(lm);
+          const isCompleted = !!triviaDoc && completedTriviaIds.has(triviaDoc._id);
+          const distance = userPos
+            ? L.latLng(userPos.latitude, userPos.longitude).distanceTo(
+                L.latLng(lm.coordinates.latitude, lm.coordinates.longitude)
+              )
+            : Infinity;
+          const isNear =
+            userPos != null &&
+            !!triviaDoc &&
+            !isCompleted &&
+            distance <= PROXIMITY_METERS;
+
+          return (
+            <Marker
+              key={lm._id}
+              position={[lm.coordinates.latitude, lm.coordinates.longitude]}
+              icon={isCompleted ? completedIcon : isNear ? nearIcon : defaultIcon}
+            >
+              <Popup>
+                <LandmarkPopup
+                  lm={lm}
+                  isAdmin={isAdmin}
+                  isNear={isNear}
+                  isCompleted={isCompleted}
+                  triviaDoc={triviaDoc}
+                  currentUser={currentUser}
+                  onCorrect={handleCorrectAnswer}
+                  onDelete={deleteLandmark}
+                  onTriviaSaved={fetchTrivia}
+                />
+              </Popup>
+            </Marker>
+          );
+        })}
 
         {/* draft pin for creating new landmark */}
         {draftPin && (

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -1,15 +1,37 @@
 // react-leaflet setup from https://react-leaflet.js.org/docs/start-setup/
 // geolocation api from https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
 import { useState, useEffect, useRef } from 'react';
-import { MapContainer, TileLayer, CircleMarker, Marker, Popup, useMap, useMapEvents } from 'react-leaflet';
+import { MapContainer, TileLayer, CircleMarker, Circle, Marker, Popup, useMap, useMapEvents } from 'react-leaflet';
+import L from 'leaflet';
+import markerIconUrl from 'leaflet/dist/images/marker-icon.png';
 import { apiUrl } from '../apiBase';
 import 'leaflet/dist/leaflet.css';
 import './Map.css';
 import FogOfWar from './FogOfWar';
 
 const UF_CENTER = [29.6436, -82.3549];
+const PROXIMITY_METERS = 100;
 
-function LocationMarker() {
+// pin colors are blue by default, red if in proximity but unanswered, and orange if answered
+const nearIcon = L.divIcon({
+  className: 'pin-near-icon',
+  html: `<img src="${markerIconUrl}" class="pin-near-img" alt="" />`,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+});
+
+const completedIcon = L.divIcon({
+  className: 'pin-completed-icon',
+  html: `<img src="${markerIconUrl}" class="pin-completed-img" alt="" />`,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+});
+
+const defaultIcon = new L.Icon.Default();
+
+function LocationMarker({ onPosition }) {
   const [position, setPosition] = useState(null);
   const hasPannedRef = useRef(false);
 
@@ -17,7 +39,9 @@ function LocationMarker() {
     if (!navigator.geolocation) return;
 
     const onSuccess = (pos) => {
-      setPosition([pos.coords.latitude, pos.coords.longitude]);
+      const next = [pos.coords.latitude, pos.coords.longitude];
+      setPosition(next);
+      onPosition?.({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
     };
     const onErr = () => setPosition(null);
     const opts = { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 };
@@ -25,7 +49,7 @@ function LocationMarker() {
     navigator.geolocation.getCurrentPosition(onSuccess, onErr, opts);
     const watchId = navigator.geolocation.watchPosition(onSuccess, onErr, opts);
     return () => navigator.geolocation.clearWatch(watchId);
-  }, []);
+  }, [onPosition]);
 
   if (!position) return null;
 
@@ -59,6 +83,9 @@ function PanToUser({ position, hasPannedRef }) {
 function MapClickHandler({ draftPin, setDraftPin }) {
   useMapEvents({
     click: (e) => {
+      const target = e.originalEvent?.target;
+      if (target && target.closest && target.closest('.leaflet-popup')) return;
+
       // clicking map while typing in popup was creating pins - this fixes it
       const tag = document.activeElement?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
@@ -73,6 +100,254 @@ function MapClickHandler({ draftPin, setDraftPin }) {
   return null;
 }
 
+function LandmarkPopup({
+  lm,
+  isAdmin,
+  isNear,
+  isCompleted,
+  triviaDoc,
+  currentUser,
+  onCorrect,
+  onDelete,
+  onTriviaSaved,
+}) {
+  const map = useMap();
+  const [view, setView] = useState('info');
+  const [submitting, setSubmitting] = useState(false);
+
+  const hasTrivia = !!triviaDoc;
+
+  const [newQuestion, setNewQuestion] = useState('');
+  const [newOptions, setNewOptions] = useState(['', '', '']);
+  const [newCorrectIndex, setNewCorrectIndex] = useState(0);
+
+  // admins see the orange pin / proximity circle but never answer trivia
+  const shouldAutoOpenTrivia = !isAdmin && isNear && hasTrivia && !isCompleted;
+
+  // when this landmark's popup opens, auto-jump to the trivia view for explorers
+  // standing next to an unanswered pin. matches the popup's source marker by
+  // latlng so we don't react to other pins' popup events.
+  useMapEvents({
+    popupopen: (e) => {
+      const srcLatLng = e.popup?._source?.getLatLng?.();
+      if (
+        srcLatLng &&
+        srcLatLng.lat === lm.coordinates.latitude &&
+        srcLatLng.lng === lm.coordinates.longitude
+      ) {
+        setView(shouldAutoOpenTrivia ? 'trivia' : 'info');
+      }
+    },
+  });
+
+  const handleAnswer = async (idx) => {
+    if (submitting || !triviaDoc) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(apiUrl(`/api/trivia/${triviaDoc._id}/answer`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: currentUser?.id,
+          answerIndex: idx,
+        }),
+      });
+      const data = await res.json();
+      if (data.correct) {
+        onCorrect(triviaDoc._id, data.completedTrivia);
+        setView('info');
+        map.closePopup();
+      } else {
+        setView('incorrect');
+      }
+    } catch {
+      setView('incorrect');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const resetAddTrivia = () => {
+    setNewQuestion('');
+    setNewOptions(['', '', '']);
+    setNewCorrectIndex(0);
+  };
+
+  const [triviaError, setTriviaError] = useState('');
+
+  const handleSaveTrivia = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setTriviaError('');
+    try {
+      let res;
+      if (hasTrivia) {
+        res = await fetch(apiUrl(`/api/trivia/${triviaDoc._id}`), {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            question: newQuestion.trim(),
+            options: newOptions.map((o) => o.trim()),
+            correctIndex: newCorrectIndex,
+          }),
+        });
+      } else {
+        res = await fetch(apiUrl('/api/trivia'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            coordinates: {
+              latitude: lm.coordinates.latitude,
+              longitude: lm.coordinates.longitude,
+            },
+            question: newQuestion.trim(),
+            options: newOptions.map((o) => o.trim()),
+            correctIndex: newCorrectIndex,
+          }),
+        });
+      }
+      if (res.ok) {
+        await onTriviaSaved();
+        setView('info');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        const msg = body.error || `Server error ${res.status}`;
+        setTriviaError(`${msg} (id: ${triviaDoc?._id ?? 'undefined'})`);
+        console.error('[handleSaveTrivia]', res.status, body, 'id:', triviaDoc?._id);
+      }
+    } catch (err) {
+      setTriviaError('Network error — check the server.');
+      console.error('[handleSaveTrivia] fetch failed', err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSaveTrivia =
+    newQuestion.trim() !== '' && newOptions.every((o) => o.trim() !== '');
+
+  if (view === 'trivia' && hasTrivia) {
+    return (
+      <>
+        <p className="trivia-question">{triviaDoc.question}</p>
+        <div className="trivia-options">
+          {triviaDoc.options.map((opt, i) => (
+            <button
+              key={i}
+              className="trivia-option-btn"
+              disabled={submitting}
+              onClick={() => handleAnswer(i)}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </>
+    );
+  }
+
+  if (view === 'incorrect') {
+    return (
+      <>
+        <h3>{lm.name}</h3>
+        <p className="trivia-incorrect">Incorrect, try again.</p>
+        <div className="popup-buttons trivia-form-buttons">
+          <button className="save-btn" onClick={(e) => { e.stopPropagation(); e.preventDefault(); setView('trivia'); }}>Try again</button>
+          <button className="cancel-btn" onClick={(e) => { e.stopPropagation(); e.preventDefault(); setView('info'); }}>Back</button>
+        </div>
+      </>
+    );
+  }
+
+  if (view === 'triviaForm') {
+    return (
+      <>
+        <h3>{hasTrivia ? 'Edit Trivia' : 'Add Trivia'}</h3>
+        <div className="trivia-admin-section">
+          <textarea
+            placeholder="Trivia question"
+            maxLength={500}
+            value={newQuestion}
+            onChange={(e) => setNewQuestion(e.target.value)}
+          />
+          {newOptions.map((opt, i) => (
+            <div key={i} className="trivia-admin-option-row">
+              <input
+                type="radio"
+                name="trivia-correct"
+                checked={newCorrectIndex === i}
+                onChange={() => setNewCorrectIndex(i)}
+                title="Mark as correct answer"
+              />
+              <input
+                type="text"
+                placeholder={`Option ${i + 1}`}
+                value={opt}
+                onChange={(e) => {
+                  const next = [...newOptions];
+                  next[i] = e.target.value;
+                  setNewOptions(next);
+                }}
+              />
+            </div>
+          ))}
+        </div>
+        {triviaError && <p className="trivia-save-error">{triviaError}</p>}
+        <div className="popup-buttons">
+          <button
+            className="save-btn"
+            disabled={!canSaveTrivia || submitting}
+            onClick={(e) => { e.stopPropagation(); e.preventDefault(); handleSaveTrivia(); }}
+          >
+            {submitting ? 'Saving…' : 'Save Trivia'}
+          </button>
+          <button
+            className="cancel-btn"
+            onClick={(e) => { e.stopPropagation(); e.preventDefault(); setView('info'); }}
+          >
+            Cancel
+          </button>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h3>{lm.name}</h3>
+      <span className="category-badge">{lm.category}</span>
+      <p>{lm.description}</p>
+      {isAdmin && (
+        <div className="popup-buttons">
+          <button
+            className="add-trivia-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              if (hasTrivia) {
+                setNewQuestion(triviaDoc.question);
+                setNewOptions([...triviaDoc.options]);
+                setNewCorrectIndex(triviaDoc.correctIndex);
+              } else {
+                resetAddTrivia();
+              }
+              setView('triviaForm');
+            }}
+          >
+            {hasTrivia ? 'Edit Trivia' : 'Add Trivia'}
+          </button>
+          <button
+            className="delete-pin-btn"
+            onClick={(e) => { e.stopPropagation(); e.preventDefault(); onDelete(lm._id); }}
+          >
+            Delete Pin
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
 function Map() {
   const userStr = localStorage.getItem('authUser') || sessionStorage.getItem('authUser');
   const currentUser = userStr ? JSON.parse(userStr) : null;
@@ -83,6 +358,11 @@ function Map() {
   const [pinCategory, setPinCategory] = useState('');
   const [pinDescription, setPinDescription] = useState('');
   const [landmarks, setLandmarks] = useState([]);
+  const [trivia, setTrivia] = useState([]);
+  const [userPos, setUserPos] = useState(null);
+  const [completedTriviaIds, setCompletedTriviaIds] = useState(
+    () => new Set(currentUser?.completedTrivia ?? [])
+  );
 
   // fetches saved landmarks from the database
   const fetchLandmarks = async () => {
@@ -91,8 +371,16 @@ function Map() {
     setLandmarks(data);
   };
 
+  // fetches trivia entries (separate collection, joined to landmarks by coordinates)
+  const fetchTrivia = async () => {
+    const res = await fetch(apiUrl('/api/trivia'));
+    const data = await res.json();
+    setTrivia(data);
+  };
+
   useEffect(() => {
     fetchLandmarks();
+    fetchTrivia();
   }, []);
 
   const handleCancel = () => {
@@ -115,10 +403,7 @@ function Map() {
       }),
     });
     if (res.ok) {
-      setDraftPin(null);
-      setPinName('');
-      setPinCategory('');
-      setPinDescription('');
+      handleCancel();
       fetchLandmarks();
     }
   };
@@ -132,6 +417,39 @@ function Map() {
       fetchLandmarks();
     }
   };
+
+  // called by LandmarkPopup when the user answers correctly
+  const handleCorrectAnswer = (triviaId, completedFromServer) => {
+    setCompletedTriviaIds((prev) => {
+      const next = new Set(prev);
+      next.add(triviaId);
+      return next;
+    });
+
+    // persist on the stored user so it survives a refresh
+    const listFromServer = Array.isArray(completedFromServer) ? completedFromServer : null;
+    const storageKey = 'authUser';
+    const stored =
+      localStorage.getItem(storageKey) || sessionStorage.getItem(storageKey);
+    if (!stored) return;
+    try {
+      const parsed = JSON.parse(stored);
+      parsed.completedTrivia = listFromServer
+        ?? Array.from(new Set([...(parsed.completedTrivia || []), triviaId]));
+      const target = localStorage.getItem(storageKey) ? localStorage : sessionStorage;
+      target.setItem(storageKey, JSON.stringify(parsed));
+    } catch {
+      // ignore bad JSON
+    }
+  };
+
+  // find a Trivia doc that matches a landmark by exact coordinate equality
+  const findTriviaForPin = (lm) =>
+    trivia.find(
+      (t) =>
+        t.coordinates.latitude === lm.coordinates.latitude &&
+        t.coordinates.longitude === lm.coordinates.longitude
+    );
 
   const isFormValid =
     pinName.trim() !== '' &&
@@ -153,20 +471,59 @@ function Map() {
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <FogOfWar />
-        <LocationMarker />
+        <LocationMarker onPosition={setUserPos} />
+        {isAdmin && userPos && (
+          <Circle
+            center={[userPos.latitude, userPos.longitude]}
+            radius={PROXIMITY_METERS}
+            pathOptions={{
+              color: '#f26a21',
+              weight: 2,
+              dashArray: '6 6',
+              fillColor: '#f26a21',
+              fillOpacity: 0.08,
+            }}
+          />
+        )}
         {isAdmin && <MapClickHandler draftPin={draftPin} setDraftPin={setDraftPin} />}
 
         {/* permanent landmarks from db */}
-        {landmarks.map((lm) => (
-          <Marker key={lm._id} position={[lm.coordinates.latitude, lm.coordinates.longitude]}>
-            <Popup>
-              <h3>{lm.name}</h3>
-              <span className="category-badge">{lm.category}</span>
-              <p>{lm.description}</p>
-              {isAdmin && <button className="delete-pin-btn" onClick={() => deleteLandmark(lm._id)}>Delete Pin</button>}
-            </Popup>
-          </Marker>
-        ))}
+        {landmarks.map((lm) => {
+          const triviaDoc = findTriviaForPin(lm);
+          const isCompleted = !!triviaDoc && completedTriviaIds.has(triviaDoc._id);
+          const distance = userPos
+            ? L.latLng(userPos.latitude, userPos.longitude).distanceTo(
+                L.latLng(lm.coordinates.latitude, lm.coordinates.longitude)
+              )
+            : Infinity;
+          const isNear =
+            userPos != null &&
+            !!triviaDoc &&
+            !isCompleted &&
+            distance <= PROXIMITY_METERS;
+
+          return (
+            <Marker
+              key={lm._id}
+              position={[lm.coordinates.latitude, lm.coordinates.longitude]}
+              icon={isCompleted ? completedIcon : isNear ? nearIcon : defaultIcon}
+            >
+              <Popup>
+                <LandmarkPopup
+                  lm={lm}
+                  isAdmin={isAdmin}
+                  isNear={isNear}
+                  isCompleted={isCompleted}
+                  triviaDoc={triviaDoc}
+                  currentUser={currentUser}
+                  onCorrect={handleCorrectAnswer}
+                  onDelete={deleteLandmark}
+                  onTriviaSaved={fetchTrivia}
+                />
+              </Popup>
+            </Marker>
+          );
+        })}
 
         {/* draft pin for creating new landmark */}
         {draftPin && (

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -1,6 +1,6 @@
 // react-leaflet setup from https://react-leaflet.js.org/docs/start-setup/
 // geolocation api from https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { MapContainer, TileLayer, CircleMarker, Circle, Marker, Popup, useMap, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import markerIconUrl from 'leaflet/dist/images/marker-icon.png';
@@ -12,7 +12,8 @@ import FogOfWar from './FogOfWar';
 const UF_CENTER = [29.6436, -82.3549];
 const PROXIMITY_METERS = 100;
 
-// pin colors are blue by default, red if in proximity but unanswered, and orange if answered
+// pin colors: blue (default), red (in proximity, unanswered), orange (answered)
+// Leaflet divIcon https://leafletjs.com/reference.html#divicon
 const nearIcon = L.divIcon({
   className: 'pin-near-icon',
   html: `<img src="${markerIconUrl}" class="pin-near-img" alt="" />`,
@@ -29,24 +30,43 @@ const completedIcon = L.divIcon({
   popupAnchor: [1, -34],
 });
 
+// Leaflet default icon https://leafletjs.com/reference.html#icon-default
 const defaultIcon = new L.Icon.Default();
 
 function LocationMarker({ onPosition }) {
   const [position, setPosition] = useState(null);
   const hasPannedRef = useRef(false);
+  // track last-reported position so we can throttle redundant state updates
+  const lastPosRef = useRef(null);
 
   useEffect(() => {
     if (!navigator.geolocation) return;
 
     const onSuccess = (pos) => {
-      const next = [pos.coords.latitude, pos.coords.longitude];
+      const { latitude, longitude } = pos.coords;
+
+      // Geolocation throttle pattern from MDN https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API
+      const prev = lastPosRef.current;
+      if (prev) {
+        const dLat = Math.abs(latitude - prev.latitude);
+        const dLng = Math.abs(longitude - prev.longitude);
+        const now = Date.now();
+
+        if (dLat < 0.00003 && dLng < 0.00003 && now - prev.ts < 2000) return;
+      }
+      lastPosRef.current = { latitude, longitude, ts: Date.now() };
+
+      const next = [latitude, longitude];
       setPosition(next);
-      onPosition?.({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+      onPosition?.({ latitude, longitude });
     };
     const onErr = () => setPosition(null);
-    const opts = { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 };
+
+    // PositionOptions https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions
+    const opts = { enableHighAccuracy: true, timeout: 10000, maximumAge: 3000 };
 
     navigator.geolocation.getCurrentPosition(onSuccess, onErr, opts);
+    // watchPosition https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition
     const watchId = navigator.geolocation.watchPosition(onSuccess, onErr, opts);
     return () => navigator.geolocation.clearWatch(watchId);
   }, [onPosition]);
@@ -55,6 +75,7 @@ function LocationMarker({ onPosition }) {
 
   return (
     <>
+      {/* CircleMarker https://leafletjs.com/reference.html#circlemarker */}
       <CircleMarker
         center={position}
         radius={12}
@@ -81,6 +102,7 @@ function PanToUser({ position, hasPannedRef }) {
 }
 
 function MapClickHandler({ draftPin, setDraftPin }) {
+  // useMapEvents https://react-leaflet.js.org/docs/api-map/#usemapevents
   useMapEvents({
     click: (e) => {
       const target = e.originalEvent?.target;
@@ -100,6 +122,22 @@ function MapClickHandler({ draftPin, setDraftPin }) {
   return null;
 }
 
+// Leaflet popupopen event https://leafletjs.com/reference.html#map-popupopen
+// useRef pattern https://react.dev/reference/react/useRef
+function PopupOpenDispatcher({ popupOpenSetters }) {
+  // useMapEvents https://react-leaflet.js.org/docs/api-map/#usemapevents
+  useMapEvents({
+    popupopen: (e) => {
+      // e.popup._source is the Leaflet layer that owns the popup
+      const src = e.popup?._source?.getLatLng?.();
+      if (!src) return;
+      const setter = popupOpenSetters.current.get(`${src.lat},${src.lng}`);
+      setter?.();
+    },
+  });
+  return null;
+}
+
 function LandmarkPopup({
   lm,
   isAdmin,
@@ -110,6 +148,7 @@ function LandmarkPopup({
   onCorrect,
   onDelete,
   onTriviaSaved,
+  popupOpenSetters,
 }) {
   const map = useMap();
   const [view, setView] = useState('info');
@@ -121,25 +160,20 @@ function LandmarkPopup({
   const [newOptions, setNewOptions] = useState(['', '', '']);
   const [newCorrectIndex, setNewCorrectIndex] = useState(0);
 
-  // admins see the orange pin / proximity circle but never answer trivia
-  const shouldAutoOpenTrivia = !isAdmin && isNear && hasTrivia && !isCompleted;
+  const coordKey = `${lm.coordinates.latitude},${lm.coordinates.longitude}`;
 
-  // when this landmark's popup opens, auto-jump to the trivia view for explorers
-  // standing next to an unanswered pin. matches the popup's source marker by
-  // latlng so we don't react to other pins' popup events.
-  useMapEvents({
-    popupopen: (e) => {
-      const srcLatLng = e.popup?._source?.getLatLng?.();
-      if (
-        srcLatLng &&
-        srcLatLng.lat === lm.coordinates.latitude &&
-        srcLatLng.lng === lm.coordinates.longitude
-      ) {
-        setView(shouldAutoOpenTrivia ? 'trivia' : 'info');
-      }
-    },
-  });
 
+  useEffect(() => {
+    const shouldAutoOpenTrivia = !isAdmin && isNear && hasTrivia && !isCompleted;
+    popupOpenSetters.current.set(coordKey, () => {
+      setView(shouldAutoOpenTrivia ? 'trivia' : 'info');
+    });
+    return () => {
+      popupOpenSetters.current.delete(coordKey);
+    };
+  }, [coordKey, isAdmin, isNear, hasTrivia, isCompleted, popupOpenSetters]);
+
+  // fetch https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
   const handleAnswer = async (idx) => {
     if (submitting || !triviaDoc) return;
     setSubmitting(true);
@@ -212,7 +246,7 @@ function LandmarkPopup({
       } else {
         const body = await res.json().catch(() => ({}));
         const msg = body.error || `Server error ${res.status}`;
-        setTriviaError(`${msg} (id: ${triviaDoc?._id ?? 'undefined'})`);
+        setTriviaError(msg);
         console.error('[handleSaveTrivia]', res.status, body, 'id:', triviaDoc?._id);
       }
     } catch (err) {
@@ -293,7 +327,7 @@ function LandmarkPopup({
           ))}
         </div>
         {triviaError && <p className="trivia-save-error">{triviaError}</p>}
-        <div className="popup-buttons">
+        <div className="popup-buttons trivia-form-buttons">
           <button
             className="save-btn"
             disabled={!canSaveTrivia || submitting}
@@ -303,7 +337,7 @@ function LandmarkPopup({
           </button>
           <button
             className="cancel-btn"
-            onClick={(e) => { e.stopPropagation(); e.preventDefault(); setView('info'); }}
+            onClick={(e) => { e.stopPropagation(); e.preventDefault(); map.closePopup(); setView('info'); }}
           >
             Cancel
           </button>
@@ -348,10 +382,13 @@ function LandmarkPopup({
   );
 }
 
-function Map() {
-  const userStr = localStorage.getItem('authUser') || sessionStorage.getItem('authUser');
-  const currentUser = userStr ? JSON.parse(userStr) : null;
-  const isAdmin = currentUser?.role === 'Admin';
+function MapPage() {
+  // per session. useMemo https://react.dev/reference/react/useMemo
+  const { currentUser, isAdmin } = useMemo(() => {
+    const userStr = localStorage.getItem('authUser') || sessionStorage.getItem('authUser');
+    const cu = userStr ? JSON.parse(userStr) : null;
+    return { currentUser: cu, isAdmin: cu?.role === 'Admin' };
+  }, []);
 
   const [draftPin, setDraftPin] = useState(null);
   const [pinName, setPinName] = useState('');
@@ -364,14 +401,16 @@ function Map() {
     () => new Set(currentUser?.completedTrivia ?? [])
   );
 
-  // fetches saved landmarks from the database
+  // useRef https://react.dev/reference/react/useRef
+  const popupOpenSetters = useRef(new Map());
+
+  // fetch https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
   const fetchLandmarks = async () => {
     const res = await fetch(apiUrl('/api/landmarks'));
     const data = await res.json();
     setLandmarks(data);
   };
 
-  // fetches trivia entries (separate collection, joined to landmarks by coordinates)
   const fetchTrivia = async () => {
     const res = await fetch(apiUrl('/api/trivia'));
     const data = await res.json();
@@ -390,7 +429,6 @@ function Map() {
     setPinDescription('');
   };
 
-  // saves a new landmark to the database
   const handleSave = async () => {
     const res = await fetch(apiUrl('/api/landmarks'), {
       method: 'POST',
@@ -408,7 +446,6 @@ function Map() {
     }
   };
 
-  // deletes a landmark from the database
   const deleteLandmark = async (id) => {
     const res = await fetch(apiUrl(`/api/landmarks/${id}`), {
       method: 'DELETE',
@@ -418,7 +455,6 @@ function Map() {
     }
   };
 
-  // called by LandmarkPopup when the user answers correctly
   const handleCorrectAnswer = (triviaId, completedFromServer) => {
     setCompletedTriviaIds((prev) => {
       const next = new Set(prev);
@@ -426,7 +462,7 @@ function Map() {
       return next;
     });
 
-    // persist on the stored user so it survives a refresh
+    // persist on the stored user so completedTrivia survives a page refresh
     const listFromServer = Array.isArray(completedFromServer) ? completedFromServer : null;
     const storageKey = 'authUser';
     const stored =
@@ -434,6 +470,8 @@ function Map() {
     if (!stored) return;
     try {
       const parsed = JSON.parse(stored);
+      // $addToSet equivalent on the client array
+      // MongoDB $addToSet https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/
       parsed.completedTrivia = listFromServer
         ?? Array.from(new Set([...(parsed.completedTrivia || []), triviaId]));
       const target = localStorage.getItem(storageKey) ? localStorage : sessionStorage;
@@ -443,13 +481,20 @@ function Map() {
     }
   };
 
-  // find a Trivia doc that matches a landmark by exact coordinate equality
-  const findTriviaForPin = (lm) =>
-    trivia.find(
-      (t) =>
-        t.coordinates.latitude === lm.coordinates.latitude &&
-        t.coordinates.longitude === lm.coordinates.longitude
-    );
+  // useMemo https://react.dev/reference/react/useMemo
+  const triviaByCoord = useMemo(() => {
+    const m = new Map();
+    for (const t of trivia) {
+      m.set(`${t.coordinates.latitude},${t.coordinates.longitude}`, t);
+    }
+    return m;
+  }, [trivia]);
+
+  // useCallback https://react.dev/reference/react/useCallback
+  const findTriviaForPin = useCallback(
+    (lm) => triviaByCoord.get(`${lm.coordinates.latitude},${lm.coordinates.longitude}`),
+    [triviaByCoord]
+  );
 
   const isFormValid =
     pinName.trim() !== '' &&
@@ -465,6 +510,8 @@ function Map() {
         maxZoom={18}
         scrollWheelZoom={true}
       >
+        {/* OSM tile layer — tile URL from https://wiki.openstreetmap.org/wiki/Tile_servers
+            attribution required by https://www.openstreetmap.org/copyright */}
         <TileLayer
           className="fog-gray"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -472,6 +519,8 @@ function Map() {
         />
         <FogOfWar />
         <LocationMarker onPosition={setUserPos} />
+        {/* Circle draws the 100 m proximity radius in admin view
+            Leaflet Circle https://leafletjs.com/reference.html#circle */}
         {isAdmin && userPos && (
           <Circle
             center={[userPos.latitude, userPos.longitude]}
@@ -487,20 +536,28 @@ function Map() {
         )}
         {isAdmin && <MapClickHandler draftPin={draftPin} setDraftPin={setDraftPin} />}
 
+        {/* single dispatcher handles popupopen for all pins in one listener */}
+        <PopupOpenDispatcher popupOpenSetters={popupOpenSetters} />
+
         {/* permanent landmarks from db */}
         {landmarks.map((lm) => {
           const triviaDoc = findTriviaForPin(lm);
           const isCompleted = !!triviaDoc && completedTriviaIds.has(triviaDoc._id);
-          const distance = userPos
-            ? L.latLng(userPos.latitude, userPos.longitude).distanceTo(
+
+          // skip distance math for pins the user can't interact with
+          let isNear = false;
+          if (triviaDoc && !isCompleted && userPos) {
+            // math reference https://en.wikipedia.org/wiki/Decimal_degrees
+            const dLat = Math.abs(userPos.latitude - lm.coordinates.latitude);
+            const dLng = Math.abs(userPos.longitude - lm.coordinates.longitude);
+            if (dLat < 0.0015 && dLng < 0.0015) {
+              // Leaflet distanceTo (Haversine) https://leafletjs.com/reference.html#latlng-distanceto
+              const distance = L.latLng(userPos.latitude, userPos.longitude).distanceTo(
                 L.latLng(lm.coordinates.latitude, lm.coordinates.longitude)
-              )
-            : Infinity;
-          const isNear =
-            userPos != null &&
-            !!triviaDoc &&
-            !isCompleted &&
-            distance <= PROXIMITY_METERS;
+              );
+              isNear = distance <= PROXIMITY_METERS;
+            }
+          }
 
           return (
             <Marker
@@ -519,6 +576,7 @@ function Map() {
                   onCorrect={handleCorrectAnswer}
                   onDelete={deleteLandmark}
                   onTriviaSaved={fetchTrivia}
+                  popupOpenSetters={popupOpenSetters}
                 />
               </Popup>
             </Marker>
@@ -573,4 +631,4 @@ function Map() {
   );
 }
 
-export default Map;
+export default MapPage;

--- a/server/models/Trivia.js
+++ b/server/models/Trivia.js
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose';
+
+const triviaSchema = new mongoose.Schema({
+  coordinates: {
+    latitude: { type: Number, required: true },
+    longitude: { type: Number, required: true },
+  },
+  question: { type: String, required: true },
+  options: {
+    type: [String],
+    required: true,
+    validate: {
+      validator: (v) => Array.isArray(v) && v.length === 3,
+      message: 'trivia must have exactly 3 options',
+    },
+  },
+  correctIndex: { type: Number, required: true, min: 0, max: 2 },
+});
+
+export default mongoose.model('Trivia', triviaSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -18,6 +18,10 @@ const userSchema = new mongoose.Schema({
     type: String,
     default: 'Explorer',
   },
+  completedTrivia: {
+    type: [String],
+    default: [],
+  },
 });
 
 const User = mongoose.model('User', userSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "node server.js"
+    "dev": "node --watch server.js"
   },
   "dependencies": {
     "bcryptjs": "^3.0.3",

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -56,6 +56,7 @@ router.post('/login', async (req, res) => {
         username: user.username,
         email: user.email,
         role: user.role,
+        completedTrivia: user.completedTrivia || [],
       },
     });
   } catch (err) {

--- a/server/routes/landmarks.js
+++ b/server/routes/landmarks.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import Landmark from '../models/Landmark.js';
+import User from '../models/User.js';
+import Trivia from '../models/Trivia.js';
 
 // mongoose crud from https://mongoosejs.com/docs/queries.html
 // basic crud for landmarks - no auth check yet, thats for sprint 2
@@ -25,11 +27,47 @@ router.get('/', async (req, res) => {
   }
 });
 
-// DELETE — deletes a landmark
+// DELETE — deletes a landmark and its associated trivia (matched by coordinates)
 router.delete('/:id', async (req, res) => {
   try {
-    await Landmark.findByIdAndDelete(req.params.id);
+    const landmark = await Landmark.findByIdAndDelete(req.params.id);
+    if (landmark) {
+      await Trivia.deleteOne({
+        'coordinates.latitude': landmark.coordinates.latitude,
+        'coordinates.longitude': landmark.coordinates.longitude,
+      });
+    }
     res.json({ message: 'Landmark deleted' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST — answer a landmark's trivia question
+// body: { userId, answerIndex }
+router.post('/:id/answer', async (req, res) => {
+  try {
+    const { userId, answerIndex } = req.body;
+    const landmark = await Landmark.findById(req.params.id);
+    if (!landmark) return res.status(404).json({ error: 'Landmark not found' });
+    if (!landmark.trivia || landmark.trivia.correctIndex == null) {
+      return res.status(400).json({ error: 'No trivia on this landmark' });
+    }
+
+    const correct = Number(answerIndex) === landmark.trivia.correctIndex;
+
+    let completedLandmarks;
+    if (correct && userId) {
+      // $addToSet keeps the list unique - https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/
+      const updated = await User.findByIdAndUpdate(
+        userId,
+        { $addToSet: { completedLandmarks: landmark.name } },
+        { new: true }
+      );
+      completedLandmarks = updated?.completedLandmarks || [];
+    }
+
+    res.json({ correct, completedLandmarks });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/server/routes/trivia.js
+++ b/server/routes/trivia.js
@@ -1,3 +1,4 @@
+// Express router https://expressjs.com/en/guide/routing.html
 import express from 'express';
 import Trivia from '../models/Trivia.js';
 import User from '../models/User.js';
@@ -5,6 +6,7 @@ import User from '../models/User.js';
 const router = express.Router();
 
 // GET — all trivia entries
+// Mongoose find https://mongoosejs.com/docs/api/model.html#Model.find()
 router.get('/', async (req, res) => {
   try {
     const trivia = await Trivia.find();
@@ -14,7 +16,8 @@ router.get('/', async (req, res) => {
   }
 });
 
-// POST — create a new trivia entry for a landmark (admin copies coordinates from the pin)
+// POST — create a new trivia entry (admin supplies coordinates copied from the pin)
+// Mongoose create https://mongoosejs.com/docs/api/model.html#Model.create()
 router.post('/', async (req, res) => {
   try {
     const trivia = await Trivia.create(req.body);
@@ -25,18 +28,18 @@ router.post('/', async (req, res) => {
 });
 
 // PUT — edit an existing trivia entry (coordinates are not editable)
+// Mongoose findByIdAndUpdate https://mongoosejs.com/docs/api/model.html#Model.findByIdAndUpdate()
+// runValidators + context: 'query' required for update validators on arrays
+// https://mongoosejs.com/docs/validation.html#update-validators
 router.put('/:id', async (req, res) => {
   try {
     const { question, options, correctIndex } = req.body;
-    // debugging :(
-    console.log('[PUT /api/trivia/:id] id =', req.params.id);
-    const trivia = await Trivia.findById(req.params.id);
-    console.log('[PUT /api/trivia/:id] found =', trivia ? trivia._id : null);
+    const trivia = await Trivia.findByIdAndUpdate(
+      req.params.id,
+      { question, options, correctIndex },
+      { new: true, runValidators: true, context: 'query' }
+    );
     if (!trivia) return res.status(404).json({ error: 'Trivia not found' });
-    trivia.question = question;
-    trivia.options = options;
-    trivia.correctIndex = correctIndex;
-    await trivia.save();
     res.json(trivia);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -44,6 +47,7 @@ router.put('/:id', async (req, res) => {
 });
 
 // DELETE — remove a trivia entry
+// Mongoose findByIdAndDelete https://mongoosejs.com/docs/api/model.html#Model.findByIdAndDelete()
 router.delete('/:id', async (req, res) => {
   try {
     await Trivia.findByIdAndDelete(req.params.id);
@@ -53,8 +57,9 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
-// POST — answer a trivia question
+// POST — submit an answer to a trivia question
 // body: { userId, answerIndex }
+// MongoDB $addToSet https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/
 router.post('/:id/answer', async (req, res) => {
   try {
     const { userId, answerIndex } = req.body;
@@ -65,7 +70,7 @@ router.post('/:id/answer', async (req, res) => {
 
     let completedTrivia;
     if (correct && userId) {
-      // $addToSet keeps the list unique - https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/
+      // $addToSet keeps the array unique without a manual dedup step
       const updated = await User.findByIdAndUpdate(
         userId,
         { $addToSet: { completedTrivia: trivia._id.toString() } },

--- a/server/routes/trivia.js
+++ b/server/routes/trivia.js
@@ -1,0 +1,83 @@
+import express from 'express';
+import Trivia from '../models/Trivia.js';
+import User from '../models/User.js';
+
+const router = express.Router();
+
+// GET — all trivia entries
+router.get('/', async (req, res) => {
+  try {
+    const trivia = await Trivia.find();
+    res.json(trivia);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST — create a new trivia entry for a landmark (admin copies coordinates from the pin)
+router.post('/', async (req, res) => {
+  try {
+    const trivia = await Trivia.create(req.body);
+    res.status(201).json(trivia);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// PUT — edit an existing trivia entry (coordinates are not editable)
+router.put('/:id', async (req, res) => {
+  try {
+    const { question, options, correctIndex } = req.body;
+    // debugging :(
+    console.log('[PUT /api/trivia/:id] id =', req.params.id);
+    const trivia = await Trivia.findById(req.params.id);
+    console.log('[PUT /api/trivia/:id] found =', trivia ? trivia._id : null);
+    if (!trivia) return res.status(404).json({ error: 'Trivia not found' });
+    trivia.question = question;
+    trivia.options = options;
+    trivia.correctIndex = correctIndex;
+    await trivia.save();
+    res.json(trivia);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// DELETE — remove a trivia entry
+router.delete('/:id', async (req, res) => {
+  try {
+    await Trivia.findByIdAndDelete(req.params.id);
+    res.json({ message: 'Trivia deleted' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST — answer a trivia question
+// body: { userId, answerIndex }
+router.post('/:id/answer', async (req, res) => {
+  try {
+    const { userId, answerIndex } = req.body;
+    const trivia = await Trivia.findById(req.params.id);
+    if (!trivia) return res.status(404).json({ error: 'Trivia not found' });
+
+    const correct = Number(answerIndex) === trivia.correctIndex;
+
+    let completedTrivia;
+    if (correct && userId) {
+      // $addToSet keeps the list unique - https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/
+      const updated = await User.findByIdAndUpdate(
+        userId,
+        { $addToSet: { completedTrivia: trivia._id.toString() } },
+        { new: true }
+      );
+      completedTrivia = updated?.completedTrivia || [];
+    }
+
+    res.json({ correct, completedTrivia });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import landmarkRoutes from './routes/landmarks.js';
 import authRoutes from './routes/auth.js';
+import triviaRoutes from './routes/trivia.js';
 
 dns.setServers(['8.8.8.8', '8.8.4.4']); // fixes dns issues with mongodb connection 
 // apparently is a node.js on windows issue 
@@ -24,6 +25,7 @@ app.get('/api/health', (req, res) => res.json({ status: 'ok' }));
 
 app.use('/api/auth', authRoutes);
 app.use('/api/landmarks', landmarkRoutes);
+app.use('/api/trivia', triviaRoutes);
 
 const port = Number(process.env.PORT) || 5000;
 app.listen(port, () => console.log(`Server on port ${port}`));


### PR DESCRIPTION
## Summary

Added proximity-based trivia to map pins:
- Pins turn **red** within 100 m when unanswered trivia is available, **orange** once answered
- Explorers clicking a red pin go straight to the trivia question; a correct answer turns the pin orange permanently
- Trivia lives in its own `Trivia` collection linked to pins by coordinates, so trivia can be added to existing pins without recreating them
- Admins can add/edit trivia per pin and see a dashed proximity circle on the map; deleting a pin also deletes its trivia

## Files changed
- `server/models/Trivia.js` — new schema
- `server/models/User.js` — added `completedTrivia` field
- `server/routes/trivia.js` — new CRUD + answer endpoints
- `server/routes/landmarks.js` — cascade-delete trivia on pin delete
- `client/src/pages/Map.jsx` — pin states, trivia popup flow, admin form
- `client/src/pages/Map.css` — pin color filters, trivia popup styles

## Test plan
- [ ] Outside 100 m → blue pin → normal info card
- [ ] Inside 100 m → red pin → trivia question opens automatically
- [ ] Wrong answer → "Try again" screen; correct answer → pin turns orange, persists on refresh
- [ ] Admin: add trivia, edit trivia, delete pin (trivia also removed)
- [ ] Admin does not see the trivia answer button

## Explorer View
<img width="770" height="750" alt="image" src="https://github.com/user-attachments/assets/55478ab2-0fbc-45e1-8ab6-63d63fd98b9b" />

## Admin View
<img width="770" height="750" alt="image" src="https://github.com/user-attachments/assets/a93c4b1d-75d3-4dea-844c-ce752accd8ef" />

Closes #32 
Closes #35 