### PR TITLE
Feat: Integrate challenge progress tracking with trivia system

### DIFF
--- a/client/src/data/badges.js
+++ b/client/src/data/badges.js
@@ -1,4 +1,4 @@
-/** Placeholder total for completion % until the Challenges feature exists. */
+/** Total number of challenges — must match CHALLENGES.length in challenges.js. */
 export const PLANNED_CHALLENGE_COUNT = 12;
 
 // Unlock when the user has completed at least `minCompleted` challenges (any order).

--- a/client/src/data/challenges.js
+++ b/client/src/data/challenges.js
@@ -1,0 +1,95 @@
+// Challenge definitions for the Badges page.
+// Each challenge tracks trivia completion at specific landmarks.
+//
+// There are 3 types of challenges:
+//    'specific' — requires completing trivia at every landmark in requiredLandmarks.
+//    'threshold' — requires completing trivia at any N landmarks total.
+//    'all' — requires completing trivia at every landmark that has trivia.
+//
+// requiredLandmarks values must match the landmark `name` field in MongoDB exactly.
+
+export const CHALLENGES = [
+  {
+    id: 'freshman-orientation',
+    name: 'Freshman Orientation',
+    description: 'Complete trivia at your very first pin anywhere on the map to begin your journey.',
+    type: 'threshold',
+    requiredCount: 1,
+  },
+  {
+    id: 'campus-tour-guide',
+    name: 'The Campus Tour Guide',
+    description: 'Visit and conquer the fundamental staples of the UF campus by completing the trivia at Century Tower, Turlington Plaza, and The Hub.',
+    type: 'specific',
+    requiredLandmarks: ['Century Tower', 'Turlington Plaza', 'The Hub'],
+  },
+  {
+    id: 'landmark-legend',
+    name: 'Landmark Legend',
+    description: 'Complete the trivia at the Landmark-category pins: Century Tower, French Fries, The Potato, Turlington Plaza, and the UF Bat Houses.',
+    type: 'specific',
+    requiredLandmarks: ['Century Tower', 'French Fries', 'The Potato', 'Turlington Plaza', 'UF Bat Houses'],
+  },
+  {
+    id: 'dining-connoisseur',
+    name: 'Dining Connoisseur',
+    description: 'Complete the trivia at all Dining-category locations: Broward Dining, Gator Corner Dining Center, The Hub, Reitz Union Food Court, and United Table at Racquet Club.',
+    type: 'specific',
+    requiredLandmarks: ['Broward Dining', 'Gator Corner Dining Center', 'The Hub', 'Reitz Union Food Court', 'United Table at Racquet Club'],
+  },
+  {
+    id: 'the-resident',
+    name: 'The Resident',
+    description: 'Complete the trivia at the Housing-category locations: Broward Hall, Beaty Towers, Hume Hall, Murphree Area, and Honors Village.',
+    type: 'specific',
+    requiredLandmarks: ['Broward Hall', 'Beaty Towers', 'Hume Hall', 'Murphree Area', 'Honors Village'],
+  },
+  {
+    id: 'the-bookworm',
+    name: 'The Bookworm',
+    description: 'Complete the trivia at every Library-category location: Library West, Marston Science Library, Smathers Library, and Architecture & Fine Arts Library.',
+    type: 'specific',
+    requiredLandmarks: ['Library West', 'Marston Science Library', 'Smathers Library', 'Architecture & Fine Arts Library'],
+  },
+  {
+    id: 'food-art-critic',
+    name: 'Food Art Critic',
+    description: 'Complete trivia at both of UF\'s food-shaped sculptures: the French Fries and The Potato.',
+    type: 'specific',
+    requiredLandmarks: ['French Fries', 'The Potato'],
+  },
+  {
+    id: 'east-campus-explorer',
+    name: 'The East Campus Explorer',
+    description: 'Complete the trivia for the pins clustered on the eastern side of campus: Broward Hall, Honors Village, and Cypress Hall.',
+    type: 'specific',
+    requiredLandmarks: ['Broward Hall', 'Honors Village', 'Cypress Hall'],
+  },
+  {
+    id: 'heart-of-campus',
+    name: 'The Heart of Campus',
+    description: 'Complete the trivia for the central campus pins: Century Tower, Turlington Plaza, Library West, and The Hub.',
+    type: 'specific',
+    requiredLandmarks: ['Century Tower', 'Turlington Plaza', 'Library West', 'The Hub'],
+  },
+  {
+    id: 'half-dozen',
+    name: 'Half Dozen Hero',
+    description: 'Complete trivia at any six different locations across the map.',
+    type: 'threshold',
+    requiredCount: 6,
+  },
+  {
+    id: 'double-digits',
+    name: 'Double Digits',
+    description: 'Complete trivia at ten different locations.',
+    type: 'threshold',
+    requiredCount: 10,
+  },
+  {
+    id: 'true-florida-gator',
+    name: 'The True Florida Gator',
+    description: 'Achieve 100% completion: visit every single pin that has trivia and answer every question correctly.',
+    type: 'all',
+  },
+];

--- a/client/src/pages/Badges.css
+++ b/client/src/pages/Badges.css
@@ -136,13 +136,40 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 6px;
   padding: 0.85rem;
+  transition: border-color 0.2s;
+}
+
+/* completed challenge highlight */
+.challenge-item--done {
+  border-color: rgba(74, 222, 128, 0.4);
+  background: rgba(74, 222, 128, 0.06);
+}
+
+/* name + progress sit side-by-side */
+.challenge-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.25rem;
 }
 
 .challenge-item__name {
   font-weight: 700;
   font-size: 0.95rem;
   color: #fff;
-  margin-bottom: 0.25rem;
+}
+
+/* "2/5" progress label */
+.challenge-item__progress {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--gw-muted);
+  white-space: nowrap;
+  margin-left: 0.5rem;
+}
+
+.challenge-item--done .challenge-item__progress {
+  color: #4ade80;
 }
 
 .challenge-item__desc {

--- a/client/src/pages/Badges.jsx
+++ b/client/src/pages/Badges.jsx
@@ -1,63 +1,103 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { BADGES, PLANNED_CHALLENGE_COUNT } from '../data/badges';
-import { getCompletedChallengeIds } from '../lib/challengeProgress';
+import { CHALLENGES } from '../data/challenges';
+import { apiUrl } from '../apiBase';
 import './Badges.css';
 
-const CHALLENGES = [
-  {
-    "name": "Freshman Orientation",
-    "description": "Visit your very first pin anywhere on the map and correctly answer its trivia question to begin your journey."
-  },
-  {
-    "name": "The Campus Tour Guide",
-    "description": "Visit and conquer the fundamental staples of the UF campus. You must complete the pins at Century Tower, Ben Hill Griffin Stadium, the J. Wayne Reitz Union, and Plaza of the Americas."
-  },
-  {
-    "name": "Landmark Legend",
-    "description": "Visit and correctly answer the trivia at all locations in the Landmarks category: Century Tower, The \"French Fries\" (Alachua) Sculpture, University Auditorium, The Bat Houses, and the Albert and Alberta Statues."
-  },
-  {
-    "name": "Dining Connoisseur",
-    "description": "Visit and correctly answer the trivia at all locations in the Dining category: Gator Corner Dining Center, Broward Dining, The Hub, and the Reitz Union Food Court."
-  },
-  {
-    "name": "The Resident",
-    "description": "Visit and correctly answer the trivia at all locations in the Housing category: Broward Hall, Hume Hall, Beaty Towers, and the historic Murphree Hall."
-  },
-  {
-    "name": "The Bookworm",
-    "description": "Visit and correctly answer the trivia at all locations in the Libraries category: Library West, Marston Science Library, Smathers Library (East), and the Architecture & Fine Arts (AFA) Library."
-  },
-  {
-    "name": "The Historic Gator",
-    "description": "Complete the trivia at UF's oldest and most historically significant buildings by visiting Murphree Hall, Smathers Library (East), and University Auditorium."
-  },
-  {
-    "name": "The STEM Scholar",
-    "description": "Complete the trivia at the science and engineering-focused locations by visiting Marston Science Library, Hume Hall, and The Bat Houses."
-  },
-  {
-    "name": "The Arts & Culture Critic",
-    "description": "Complete the trivia at UF's creative hubs by visiting the Architecture & Fine Arts Library, the University Auditorium, and the \"French Fries\" (Alachua) Sculpture."
-  },
-  {
-    "name": "The East Campus Explorer",
-    "description": "Complete the trivia for the pins clustered on the eastern side of campus by visiting Beaty Towers, Broward Hall, and Broward Dining."
-  },
-  {
-    "name": "The Heart of Campus",
-    "description": "Complete the trivia for the high-traffic central campus pins by visiting Library West, The Hub, and Century Tower."
-  },
-  {
-    "name": "The True Florida Gator",
-    "description": "Achieve 100% completion. Visit every single pin across all four categories (Landmarks, Dining, Housing, and Libraries) and answer all the trivia questions correctly."
-  }
-];
+// Helpers:
 
-function buildStats(completedIds) {
+// Reads the logged-in user's completedTrivia array from local/session storage.
+// This is the same storage key the auth flow and Map.jsx write to.
+function getCompletedTriviaIds() {
+  try {
+    const raw =
+      localStorage.getItem('authUser') || sessionStorage.getItem('authUser');
+    const user = JSON.parse(raw || 'null');
+    return user?.completedTrivia ?? [];
+  } catch {
+    return [];
+  }
+}
+
+// Evaluates every challenge's progress against the user's completed trivia.
+//
+// landmarks & trivia come from the API; completedTriviaIds from auth storage.
+// Returns a Map<challengeId, { completed: number, total: number }>.
+//
+// How it works:
+//   1. Build a lookup from landmark name → its matching trivia _id
+//      (trivia is linked to landmarks by matching coordinates).
+//   2. For each challenge, figure out which trivia IDs are required,
+//      then count how many the user has already completed.
+function evaluateChallenges(challenges, landmarks, trivia, completedTriviaIds) {
+  const completedSet = new Set(completedTriviaIds);
+
+  // Map each trivia's coordinates to its _id for fast lookup
+  const coordToTriviaId = new Map();
+  for (const t of trivia) {
+    coordToTriviaId.set(
+      `${t.coordinates.latitude},${t.coordinates.longitude}`,
+      t._id,
+    );
+  }
+
+  // Map landmark name → trivia _id (if that landmark has trivia)
+  const nameToTriviaId = new Map();
+  for (const lm of landmarks) {
+    const key = `${lm.coordinates.latitude},${lm.coordinates.longitude}`;
+    const tId = coordToTriviaId.get(key);
+    if (tId) nameToTriviaId.set(lm.name, tId);
+  }
+
+  // Total number of trivia-enabled landmarks (used by 'all' type challenges)
+  const totalTriviaCount = nameToTriviaId.size;
+
+  const results = new Map();
+
+  for (const ch of challenges) {
+    let completed = 0;
+    let total = 0;
+
+    if (ch.type === 'threshold') {
+      // 'threshold' — user just needs N completions of anything
+      total = ch.requiredCount;
+      completed = Math.min(completedSet.size, total);
+    } else if (ch.type === 'all') {
+      // 'all' — every trivia-enabled landmark must be completed
+      total = totalTriviaCount;
+      for (const tId of nameToTriviaId.values()) {
+        if (completedSet.has(tId)) completed++;
+      }
+    } else {
+      // 'specific' — only the named landmarks count
+      total = ch.requiredLandmarks.length;
+      for (const name of ch.requiredLandmarks) {
+        const tId = nameToTriviaId.get(name);
+        if (tId && completedSet.has(tId)) completed++;
+      }
+    }
+
+    results.set(ch.id, { completed, total });
+  }
+
+  return results;
+}
+
+// Counts how many challenges the user has fully completed.
+// Used by the badge system to decide which badges to unlock.
+function countFullyCompleted(progressMap) {
+  let count = 0;
+  for (const { completed, total } of progressMap.values()) {
+    if (total > 0 && completed >= total) count++;
+  }
+  return count;
+}
+
+// Stats for the badge grid:
+
+function buildStats(completedCount) {
   const totalChallenges = PLANNED_CHALLENGE_COUNT;
-  const completedCount = completedIds.length;
   const completionPct =
     totalChallenges === 0 ? 0 : Math.round((completedCount / totalChallenges) * 100);
 
@@ -87,20 +127,46 @@ function buildStats(completedIds) {
   };
 }
 
-function Badges() {
-  const [completedIds, setCompletedIds] = useState(() => getCompletedChallengeIds());
+// Component:
 
+function Badges() {
+  const [landmarks, setLandmarks] = useState([]);
+  const [trivia, setTrivia] = useState([]);
+  const [completedTriviaIds, setCompletedTriviaIds] = useState(getCompletedTriviaIds);
+
+  // Fetch landmarks and trivia from API on mount
+  // fetch docs: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
   useEffect(() => {
-    const on = () => setCompletedIds(getCompletedChallengeIds());
-    window.addEventListener('openworld-progress', on);
-    window.addEventListener('storage', on);
-    return () => {
-      window.removeEventListener('openworld-progress', on);
-      window.removeEventListener('storage', on);
-    };
+    fetch(apiUrl('/api/landmarks'))
+      .then((r) => r.json())
+      .then(setLandmarks)
+      .catch(() => {});
+    fetch(apiUrl('/api/trivia'))
+      .then((r) => r.json())
+      .then(setTrivia)
+      .catch(() => {});
   }, []);
 
-  const stats = useMemo(() => buildStats(completedIds), [completedIds]);
+  // Re-read completed trivia when storage changes (e.g. user answers on Map page)
+  useEffect(() => {
+    const refresh = () => setCompletedTriviaIds(getCompletedTriviaIds());
+    window.addEventListener('storage', refresh);
+    return () => window.removeEventListener('storage', refresh);
+  }, []);
+
+  // Evaluate progress for every challenge
+  const progressMap = useMemo(
+    () => evaluateChallenges(CHALLENGES, landmarks, trivia, completedTriviaIds),
+    [landmarks, trivia, completedTriviaIds],
+  );
+
+  // Count how many challenges are fully done → drives badge unlocks
+  const fullyCompleted = useMemo(
+    () => countFullyCompleted(progressMap),
+    [progressMap],
+  );
+
+  const stats = useMemo(() => buildStats(fullyCompleted), [fullyCompleted]);
 
   const gridSlots = useMemo(() => {
     const maxShow = 11;
@@ -177,17 +243,30 @@ function Badges() {
           </h2>
           <div className="showcase-card__body">
             <div className="challenges-list" role="list">
-              {CHALLENGES.map((c, i) => (
-                <div key={i} className="challenge-item" role="listitem">
-                  <div className="challenge-item__name">{c.name}</div>
-                  <div className="challenge-item__desc">{c.description}</div>
-                </div>
-              ))}
+              {CHALLENGES.map((c) => {
+                const prog = progressMap.get(c.id) || { completed: 0, total: 0 };
+                const done = prog.total > 0 && prog.completed >= prog.total;
+                return (
+                  <div
+                    key={c.id}
+                    className={`challenge-item${done ? ' challenge-item--done' : ''}`}
+                    role="listitem"
+                  >
+                    <div className="challenge-item__header">
+                      <div className="challenge-item__name">{c.name}</div>
+                      <div className="challenge-item__progress">
+                        {prog.completed}/{prog.total}
+                      </div>
+                    </div>
+                    <div className="challenge-item__desc">{c.description}</div>
+                  </div>
+                );
+              })}
             </div>
 
             <div className="showcase-stat-row showcase-stat-row--duo">
               <div className="showcase-stat">
-                <div className="showcase-stat__value">{stats.completedCount}</div>
+                <div className="showcase-stat__value">{fullyCompleted}</div>
                 <div className="showcase-stat__label">Challenges completed</div>
               </div>
               <div className="showcase-stat">


### PR DESCRIPTION
## Summary
Connects the challenge system to the existing trivia backend so that completing trivia at landmarks automatically updates challenge progress on the Badges page. Each challenge now displays live progress (e.g. "2/5") based on the user's completed trivia.

## Changes
- **`client/src/data/challenges.js`** [NEW] — Challenge definitions with three types: `threshold` (complete any N trivia), `specific` (complete trivia at named landmarks), and `all` (100% completion). Updated to reflect current pins in the database.
- **`client/src/pages/Badges.jsx`** — Fetches landmarks and trivia from the API on mount, evaluates each challenge's progress by matching completed trivia IDs to landmark coordinates, and renders a progress indicator next to each challenge. Badges now unlock based on fully completed challenges.
- **`client/src/pages/Badges.css`** — Added styles for the progress label and a green highlight for completed challenges.
- **`client/src/data/badges.js`** — Updated comment (no logic changes).

## How it works
No backend changes. The client evaluates challenge progress by:
1. Reading the user's `completedTrivia` array from auth storage
2. Fetching all landmarks and trivia from the API
3. Matching trivia to landmarks by coordinates, then checking which required landmarks have been completed

`lib/challengeProgress.js` is now unused (was a localStorage stub that nothing wrote to).